### PR TITLE
Fix for redmine 3.3

### DIFF
--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -56,7 +56,7 @@
     <ul>
     <% for tracker in @trackers %>
       <li><%= link_to tracker.name, project_issues_path(@project, :set_filter => 1, :tracker_id => tracker.id) %>:
-          <%= l(:label_x_open_issues_abbr_on_total, :count => @open_issues_by_tracker[tracker].to_i,
+          <%= l(:label_x_open_issues_abbr, :count => @open_issues_by_tracker[tracker].to_i,
                                                     :total => @total_issues_by_tracker[tracker].to_i) %>
       </li>
     <% end %>


### PR DESCRIPTION
Redmine 3.3 does not include label_x_open_issues_abbr_on_total label for translation.
label_x_open_issues_abbr can be used instead of that.